### PR TITLE
Add `read_exactly`

### DIFF
--- a/lib/channel.ml
+++ b/lib/channel.ml
@@ -96,6 +96,16 @@ module Make(Flow:V1_LWT.FLOW) = struct
       Lwt.return buf
     end
 
+  let read_exactly ~len t =
+    let rec loop acc = function
+      | 0 ->
+        Lwt.return (List.rev acc)
+      | len ->
+        read_some ~len t
+        >>= fun buffer ->
+        loop (buffer :: acc) (len - (Cstruct.len buffer)) in
+    loop [] len
+
   (* Read up to len characters from the input channel as a
      stream (and read all available if no length specified *)
   let read_stream ?len t =

--- a/lib/channel.mli
+++ b/lib/channel.mli
@@ -18,4 +18,8 @@ module Make(F:V1_LWT.FLOW) : sig
   include V1_LWT.CHANNEL with type flow = F.flow
   exception Read_error of F.error
   exception Write_error of F.error
+
+  val read_exactly: len:int -> t -> Cstruct.t list io
+  (** [read_exactly len t] reads [len] bytes from the channel [t] or fails
+      with [Read_error] or [End_of_file]. *)
 end

--- a/lib_test/test_channel.ml
+++ b/lib_test/test_channel.ml
@@ -53,8 +53,17 @@ let test_read_line () =
   assert_string "read line" input (Cstruct.copyv buf);
   Lwt.return_unit
 
+let test_read_exactly () =
+  let input = "I am the very model of a modern major general" in
+  let f = Fflow.make ~input:(Fflow.input_string input) () in
+  let c = Channel.create f in
+  Channel.read_exactly ~len:4 c >>= fun bufs ->
+  assert_int "wrong length" 4 (Cstruct.(len (concat bufs)));
+  Lwt.return_unit
+
 let suite = [
   "read_char + EOF" , `Quick, test_read_char_eof;
   "read_until + EOF", `Quick, test_read_until_eof;
   "read_line"       , `Quick, test_read_line;
+  "read_exactly"    , `Quick, test_read_exactly;
 ]


### PR DESCRIPTION
When reading fixed-size records from a channel, it's convenient to
read a whole message at a time given its length. The existing
`read_some` function will return short if the internal buffer
becomes empty, so we need to call `read_some` in a loop.

Note the result of `read_exactly` is a `Cstruct.t list` since the
data may be split across multiple buffers allocated by `FLOW.read`.

Signed-off-by: David Scott <dave@recoil.org>