### PR TITLE
Fix `write` after a previous `read` has returned `EOF`

### DIFF
--- a/lib/channel.ml
+++ b/lib/channel.ml
@@ -59,9 +59,6 @@ module Make(Flow:V1_LWT.FLOW) = struct
     | `Error e ->
       Lwt.fail (Read_error e)
     | `Eof ->
-      (* close the flow before throwing exception; otherwise it will never be
-         GC'd *)
-      Flow.close t.flow >>= fun () ->
       Lwt.fail End_of_file
 
   let rec get_ibuf t =


### PR DESCRIPTION
It should be possible to `read` all the data in one direction from
a FLOW and then to still `write`, as FLOWs are bidirectional like
TCP connections.

The `FLOW.close` spec says that:

> [close flow] flushes all pending writes and signals the remote
> endpoint that there will be no future writes. Once the remote endpoint
> has read all pending data, it is expected that calls to [read] on
> the remote return [`Eof].
>
> Note it is still possible for the remote endpoint to [write] to
> the flow and for the local endpoint to call [read]. This state where
> the local endpoint has called [close] but the remote endpoint
> has not called [close] is similar to that of a half-closed TCP
> connection or a Unix socket after [shutdown(SHUTDOWN_WRITE)].

When we receive `Eof` on a `read`, we shouldn't respond by calling
`close` which affects the write side of the connection.

Note calling `close` here probably works around a leak in some other
bit of software -- the function that creates the `FLOW` or `CHANNEL`
needs to call `close` on `End_of_file` when finished -- possibly in
an exception handler -- as a similar function would call `close(fd)`
on Unix.

Signed-off-by: David Scott <dave@recoil.org>