### PR TITLE
Implement Channel.disconnect by calling Flow.disconnect

### DIFF
--- a/lib/channel.ml
+++ b/lib/channel.ml
@@ -230,4 +230,6 @@ module Make(Flow:V1_LWT.FLOW) = struct
   let close t =
     Lwt.finalize (fun () -> flush t) (fun () -> Flow.close t.flow)
 
+  let disconnect t = Flow.disconnect t.flow
+
 end


### PR DESCRIPTION
Note that Channel.close still calls Channel.flush before Flow.close.

Related to [mirage/mirage#550]

Signed-off-by: David Scott dave@recoil.org
