### PR TITLE
use resultified flow errors; pull exceptions out of functor

### DIFF
--- a/src/channel.mli
+++ b/src/channel.mli
@@ -15,12 +15,12 @@
  *)
 
 (** Buffered I/O channels over the unbuffered MirageOS FLOW interface *)
+exception Read_error of V1.Flow.error
+exception Write_error of V1.Flow.write_error
 
 (** Functor to create a CHANNEL from a {!V1_LWT.FLOW} implementation *)
 module Make(F:V1_LWT.FLOW) : sig
   include V1_LWT.CHANNEL with type flow = F.flow
-  exception Read_error of F.error
-  exception Write_error of F.error
 
   val read_exactly: len:int -> t -> Cstruct.t list io
   (** [read_exactly len t] reads [len] bytes from the channel [t] or fails


### PR DESCRIPTION
Since error message printers are no longer provided by F, the exceptions
no longer need to be inside the functor application for Channel.

This PR causes `mirage-channel` to build against the current Mirage 3 API, but will break backward compatibility with the current released `mirage` package set.  See https://github.com/mirage/mirage/pull/690 for details on the pull request there.