### PR TITLE
Refactor CHANNEL types to be exception-less and use `result`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
  global:
    - PACKAGE="channel"
    - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
-   - PINS="mirage-types:https://github.com/avsm/mirage.git#channel-result.git"
+   - PINS="mirage-types:https://github.com/avsm/mirage.git#channel-result"
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
    - POST_INSTALL_HOOK="opam depext -iu mirage && rm -rf mirage-skeleton && git clone git://github.com/mirage/mirage-skeleton -b mirage-dev && cd mirage-skeleton && opam config exec -- make MODE=unix"
  matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
  global:
    - PACKAGE="channel"
    - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
-   - PINS="mirage-types:https://github.com/avsm/mirage.git#channel-result"
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
    - POST_INSTALL_HOOK="opam depext -iu mirage && rm -rf mirage-skeleton && git clone git://github.com/mirage/mirage-skeleton -b mirage-dev && cd mirage-skeleton && opam config exec -- make MODE=unix"
  matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
  global:
    - PACKAGE="channel"
    - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
+   - PINS="mirage-types:https://github.com/avsm/mirage.git#channel-result.git"
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
    - POST_INSTALL_HOOK="opam depext -iu mirage && rm -rf mirage-skeleton && git clone git://github.com/mirage/mirage-skeleton -b mirage-dev && cd mirage-skeleton && opam config exec -- make MODE=unix"
  matrix:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+v3.0.0
+------
+
+Adapt to MirageOS 3 CHANNEL interface:
+
+- use `result` instead of exceptions
+- hide `read_until` as an internal implementation
+- remove `read_stream` from external interface as it is
+  difficult to combine Lwt_stream and error handling.
+
 v1.1.1 2016-10-20
 -----------------
 

--- a/_tags
+++ b/_tags
@@ -1,7 +1,7 @@
-true : bin_annot, safe_string, package(bytes)
+true : annot, bin_annot, safe_string, package(bytes)
 true: debug, short_paths, principal
 true: warn_error(+1..49), warn(A-4-41-44)
-true: package(io-page mirage-types.lwt cstruct lwt logs)
+true: package(io-page mirage-types.lwt cstruct lwt logs result)
 <test/*>: package(alcotest oUnit mirage-flow lwt.unix io-page.unix)
 <src> : include
 <test> : include

--- a/opam
+++ b/opam
@@ -14,6 +14,7 @@ depends: [
   "topkg" {build} 
   "mirage-types-lwt"
   "io-page"
+  "result"
   "lwt" {>= "2.4.7"}
   "cstruct"
   "logs"

--- a/pkg/META
+++ b/pkg/META
@@ -1,4 +1,4 @@
-version = "%%VERSION%%"
+version = "%%VERSION_NUM%%"
 description = "Buffered channels over Mirage FLOW implementations"
 requires = "io-page mirage-types.lwt cstruct lwt logs"
 archive(byte) = "channel.cma"

--- a/src/channel.mli
+++ b/src/channel.mli
@@ -14,15 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-(** Buffered I/O channels over the unbuffered MirageOS FLOW interface *)
-exception Read_error of V1.Flow.error
-exception Write_error of V1.Flow.write_error
-
 (** Functor to create a CHANNEL from a {!V1_LWT.FLOW} implementation *)
 module Make(F:V1_LWT.FLOW) : sig
   include V1_LWT.CHANNEL with type flow = F.flow
-
-  val read_exactly: len:int -> t -> Cstruct.t list io
-  (** [read_exactly len t] reads [len] bytes from the channel [t] or fails
-      with [Read_error] or [End_of_file]. *)
 end

--- a/test/common.ml
+++ b/test/common.ml
@@ -1,4 +1,5 @@
 let (>>=) = Lwt.(>>=)
+let (>|=) = Lwt.(>|=)
 
 let fail fmt = Printf.ksprintf OUnit.assert_failure fmt
 

--- a/test/test_channel.ml
+++ b/test/test_channel.ml
@@ -5,8 +5,10 @@ open Common
    handled properly *)
 module Channel = Channel.Make(Fflow)
 
-let err_read ch =
-  fail "character %c was returned from Channel.read_char on an empty flow" ch
+let err_read = function
+  | Ok (`Data ch) -> fail "character %c was returned from Channel.read_char on an empty flow" ch
+  | Ok `Eof -> Lwt.return ()
+  | Error (`Msg m) -> fail "unexpected error: %s" m
 
 let err_no_exception () = fail "no exception"
 let err_wrong_exception e = fail "wrong exception: %s" (Printexc.to_string e)
@@ -14,52 +16,25 @@ let err_wrong_exception e = fail "wrong exception: %s" (Printexc.to_string e)
 let test_read_char_eof () =
   let f = Fflow.make () in
   let c = Channel.create f in
-  let try_char_read () = Channel.read_char c >>= err_read in
-  Lwt.try_bind
-    (try_char_read)
-    err_no_exception (* "success" case (no exceptions) *)
-    (function
-      | End_of_file -> Lwt.return_unit
-      | e -> err_wrong_exception e)
-
-let test_read_until_eof () =
-  let input =
-    Fflow.input_string "I am the very model of a modern major general"
-  in
-  let f = Fflow.make ~input () in
-  let c = Channel.create f in
-  Channel.read_until c 'v' >>= function
-  | true, buf ->
-    assert_cstruct "wrong flow prefix"
-      (Cstruct.of_string "I am the ") buf;
-    Channel.read_until c '\xff' >>= fun (found, buf) ->
-    assert_bool "found a char that couldn't have been there in read_until"
-      false found;
-    assert_cstruct "wrong flow suffix"
-      (Cstruct.of_string "ery model of a modern major general") buf;
-    Channel.read_until c '\n' >>= fun (found, buf) ->
-    assert_bool "found a char after EOF in read_until"
-      false found;
-    assert_int "wrong flow size" 0 (Cstruct.len buf);
-    Lwt.return_unit
-  | false, _ ->
-    OUnit.assert_failure "thought we couldn't find a 'v' in input test"
+  Channel.read_char c >>= err_read
 
 let test_read_line () =
   let input = "I am the very model of a modern major general" in
   let f = Fflow.make ~input:(Fflow.input_string input) () in
   let c = Channel.create f in
-  Channel.read_line c  >>= fun buf ->
-  assert_string "read line" input (Cstruct.copyv buf);
-  Lwt.return_unit
+  Channel.read_line c >|= function
+  | Ok (`Data buf) -> assert_string "read line" input (Cstruct.copyv buf)
+  | Ok `Eof -> fail "eof"
+  | Error (`Msg m) -> fail "error: %s" m
 
 let test_read_exactly () =
   let input = "I am the very model of a modern major general" in
   let f = Fflow.make ~input:(Fflow.input_string input) () in
   let c = Channel.create f in
-  Channel.read_exactly ~len:4 c >>= fun bufs ->
-  assert_int "wrong length" 4 (Cstruct.(len (concat bufs)));
-  Lwt.return_unit
+  Channel.read_exactly ~len:4 c >|= function
+  | Ok (`Data bufs) -> assert_int "wrong length" 4 (Cstruct.(len (concat bufs)))
+  | Ok `Eof -> fail "eof"
+  | Error (`Msg m) -> fail "error: %s" m
 
 let test_read_until_eof_then_write () =
   let str = "I am the very model of a modern major general" in
@@ -77,12 +52,13 @@ let test_read_until_eof_then_write () =
   (* Should read to EOF: *)
   Channel.read_line c >>= fun _ ->
   Channel.write_line c "Even though I've read to EOF, I should be able to write";
-  Channel.flush c >>= fun () ->
-  Lwt.return_unit
+  Channel.flush c >|= function
+  | Ok () -> ()
+  | Error `Closed -> fail "error: closed"
+  | Error (`Msg m) -> fail "error: %s" m
 
 let suite = [
   "read_char + EOF" , `Quick, test_read_char_eof;
-  "read_until + EOF", `Quick, test_read_until_eof;
   "read_line"       , `Quick, test_read_line;
   "read_exactly"    , `Quick, test_read_exactly;
   "write after read EOF", `Quick, test_read_until_eof_then_write;


### PR DESCRIPTION
- remove `read_stream` and `io_stream` as Lwt_stream is difficult to
  combine with error handling
- remove `read_until` and only expose the line handling functions.
  I'm also considering moving the line-handling functions into a
  separate signature since most consumers of CHANNEL only want the
  buffering logic.
- no more exceptions, just use `result` and propagate `FLOW.error`
  in return values.