### PR TITLE
Add an optional size limit to `read_line`

### DIFF
--- a/src/mirage_channel.ml
+++ b/src/mirage_channel.ml
@@ -71,11 +71,19 @@ module type S = sig
   (** [read_exactly len t] reads [len] bytes from the channel [t] or fails
       with [Eof]. *)
 
-  val read_line: t -> (buffer list Mirage_flow.or_eof, error) result io
-  (** [read_line t] reads a line of input, which is terminated
-      either by a CRLF sequence, or the end of the channel (which
-      counts as a line).  @return Returns a list of views that
-      terminates at EOF. *)
+  val read_line: ?len:int -> t -> (buffer list Mirage_flow.or_eof, error) result io
+  (** [read_line t] reads a line of input which is terminated either by a CRLF
+      sequence, or the end of the channel (which counts as a line).
+
+      If [?len] is provided then the maximum length of the line returned will be
+      [len] bytes. If the line is longer than [len] then an error will be
+      returned.
+
+      If the input data is untrusted then care should be taken to ensure [len]
+      is set to an application-specific small value to bound the amount of
+      memory allocated by [read_line].
+
+      @return Returns a list of views that terminates at EOF. *)
 
   val write_char: t -> char -> unit
   (** [write_char t ch] writes a single character to the output

--- a/src/mirage_channel.ml
+++ b/src/mirage_channel.ml
@@ -77,7 +77,7 @@ module type S = sig
 
       If [?len] is provided then the maximum length of the line returned will be
       [len] bytes. If the line is longer than [len] then an error will be
-      returned.
+      returned and no bytes will be read from the channel.
 
       If the input data is untrusted then care should be taken to ensure [len]
       is set to an application-specific small value to bound the amount of

--- a/src/mirage_channel.ml
+++ b/src/mirage_channel.ml
@@ -25,7 +25,7 @@
 
 module type S = sig
 
-  type error
+  type error = private [> `Line_too_long ]
   (** The type for errors. *)
 
   val pp_error: error Fmt.t

--- a/test/test_channel.ml
+++ b/test/test_channel.ml
@@ -41,7 +41,8 @@ let test_read_line_len () =
   Channel.read_line ~len:5 c >|= function
   | Ok (`Data _) -> fail "read a line which was too big"
   | Ok `Eof -> fail "eof"
-  | Error _ -> ()
+  | Error `Line_too_long -> ()
+  | Error e -> fail "error: %a" Channel.pp_error e
 
 (* The line is shorter than the limit and bounded by \r\n *)
 let test_read_line_len2 () =

--- a/test/test_channel.ml
+++ b/test/test_channel.ml
@@ -33,6 +33,36 @@ let test_read_line () =
   | Ok `Eof -> fail "eof"
   | Error e -> fail "error: %a" Channel.pp_error e
 
+(* The line is longer than the limit *)
+let test_read_line_len () =
+  let input = "I am the very model of a modern major general" in
+  let f = F.make ~input:(F.input_string input) () in
+  let c = Channel.create f in
+  Channel.read_line ~len:5 c >|= function
+  | Ok (`Data _) -> fail "read a line which was too big"
+  | Ok `Eof -> fail "eof"
+  | Error _ -> ()
+
+(* The line is shorter than the limit and bounded by \r\n *)
+let test_read_line_len2 () =
+  let input = "I\r\n am the very model of a modern major general" in
+  let f = F.make ~input:(F.input_string input) () in
+  let c = Channel.create f in
+  Channel.read_line ~len:5 c >|= function
+  | Ok (`Data buf) -> Alcotest.(check string) "read line" "I" (Cstruct.copyv buf)
+  | Ok `Eof -> fail "eof"
+  | Error e -> fail "error: %a" Channel.pp_error e
+
+(* The line is shorter than the limit and bounded by EOF *)
+let test_read_line_len3 () =
+  let input = "I am the very model of a modern major general" in
+  let f = F.make ~input:(F.input_string input) () in
+  let c = Channel.create f in
+  Channel.read_line ~len:50 c >|= function
+  | Ok (`Data buf) -> Alcotest.(check string) "read line" input (Cstruct.copyv buf)
+  | Ok `Eof -> fail "eof"
+  | Error e -> fail "error: %a" Channel.pp_error e
+
 let test_read_exactly () =
   let input = "I am the very model of a modern major general" in
   let f = F.make ~input:(F.input_string input) () in
@@ -67,6 +97,7 @@ let test_read_until_eof_then_write () =
 let suite = [
   "read_char + EOF" , `Quick, test_read_char_eof;
   "read_line"       , `Quick, test_read_line;
-  "read_exactly"    , `Quick, test_read_exactly;
-  "write after read EOF", `Quick, test_read_until_eof_then_write;
+  "read_line_len"   , `Quick, test_read_line_len;
+  "read_line_len2"  , `Quick, test_read_line_len2;
+  "read_line_len3"  , `Quick, test_read_line_len3;
 ]


### PR DESCRIPTION
Previously a call to `read_line` would read and buffer arbitrary amounts of data. If an untrusted entity supplies the data (e.g. consider a web-server reading a request or header line) then the `read_line` can be provoked into allocating so much memory that it kills the whole process / server.

This patch changes the API by adding an optional `?len` parameter (in the same style as `read_some` and `read_exactly`) to bound the maximum length of the line. If the bound is exceeded then the function returns an error (`Line_too_long`)

Users of this library dealing with untrusted data should decide on a suitable `len` value to avoid possible memory exhaustion.

This patch includes a couple of extra unit tests.

Signed-off-by: David Scott <dave@recoil.org>