### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-channel-lwt.opam
+++ b/mirage-channel-lwt.opam
@@ -8,7 +8,7 @@ doc: "http://docs.mirage.io/mirage-channel"
 bug-reports: "https://github.com/mirage/mirage-channel/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "mirage-channel" {>= "3.0.0"}
   "io-page"

--- a/mirage-channel.opam
+++ b/mirage-channel.opam
@@ -8,7 +8,7 @@ doc: "http://mirage.github.io/mirage-channel/"
 bug-reports: "https://github.com/mirage/mirage-channel/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-flow" {>= "1.2.0"}
 ]
 conflicts: [


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.