### PR TITLE
compatibility with older mirage

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,5 @@
 (library
  (name mirage_channel)
  (public_name mirage-channel)
- (libraries mirage-flow lwt cstruct logs))
+ (libraries mirage-flow lwt cstruct logs)
+ (wrapped false))

--- a/src/mirage_channel_lwt.ml
+++ b/src/mirage_channel_lwt.ml
@@ -1,0 +1,3 @@
+[@@@ocaml.deprecated "This module will be removed from MirageOS 4.0. Please use Mirage_channel instead."]
+
+include Mirage_channel


### PR DESCRIPTION
this allows a smooth transition path (mirage 3.6.0 --> 3.7.0) with some deprecations.