### PR TITLE
Restore compatibility with Alcotest.1.4.0

### DIFF
--- a/test/test_channel.ml
+++ b/test/test_channel.ml
@@ -2,7 +2,7 @@ open Lwt.Infix
 
 module F = Mirage_flow_combinators.F
 
-let fail fmt = Fmt.kstrf Alcotest.fail fmt
+let fail fmt = Fmt.kstrf (fun s -> Alcotest.fail s) fmt
 
 (* this is a very small set of tests for the channel interface,
    intended to ensure that EOF conditions on the underlying flow are


### PR DESCRIPTION
The Alcotest 1.4.0 release adds optional arguments to Alcotest.fail.  Eta-expansion is necessary to use this function with the continuation printers.