### PR TITLE
Adapt all PRs and open issues

### DIFF
--- a/mirage-channel.opam
+++ b/mirage-channel.opam
@@ -9,10 +9,11 @@ bug-reports: "https://github.com/mirage/mirage-channel/issues"
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.0"}
-  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
   "cstruct" {>= "6.0.0"}
   "logs"
+  "fmt" {>= "0.8.7"}
   "alcotest" {with-test}
   "mirage-flow-combinators" {with-test & >= "2.0.0"}
 ]

--- a/mirage-channel.opam
+++ b/mirage-channel.opam
@@ -50,3 +50,4 @@ Channel.flush t
 
 mirage-channel is distributed under the ISC license.
 """
+x-maintenance-intent: [ "(latest)" ]

--- a/src/mirage_channel.ml
+++ b/src/mirage_channel.ml
@@ -35,6 +35,7 @@ module type S = sig
   val write_line: t -> string -> unit
   val flush: t -> (unit, write_error) result Lwt.t
   val close: t -> (unit, write_error) result Lwt.t
+  val shutdown: t -> [ `read | `write | `read_write ] -> (unit, write_error) result Lwt.t
 end
 
 open Lwt.Infix
@@ -255,4 +256,6 @@ module Make(Flow: Mirage_flow.S) = struct
   let close t =
     Lwt.finalize (fun () -> flush t) (fun () -> Flow.close t.flow)
 
+  let shutdown t mode =
+    Lwt.finalize (fun () -> flush t) (fun () -> Flow.shutdown t.flow mode)
 end

--- a/src/mirage_channel.mli
+++ b/src/mirage_channel.mli
@@ -106,6 +106,9 @@ module type S = sig
   (** [close t] calls {!flush} and then close the underlying
       flow. *)
 
+  val shutdown : t -> [ `read | `write | `read_write ] -> (unit, write_error) result Lwt.t
+  (** [shutdown t mode] calls {!flush} and then shutdown on the underlying
+      flow. *)
 end
 
 (** Functor to create a CHANNEL from a flow implementation *)

--- a/src/mirage_channel_lwt.ml
+++ b/src/mirage_channel_lwt.ml
@@ -1,3 +1,0 @@
-[@@@ocaml.deprecated "This module will be removed from MirageOS 4.0. Please use Mirage_channel instead."]
-
-include Mirage_channel

--- a/test/test_channel.ml
+++ b/test/test_channel.ml
@@ -84,6 +84,7 @@ let channel_from_raw_string s =
     let write _ _ = assert false
     let writev _ _ = assert false
     let close _ = Lwt.return ()
+    let shutdown _ _ = Lwt.return_unit
   end in
   let module Channel = Mirage_channel.Make(Flow) in
   V ((module Channel), Channel.create ())


### PR DESCRIPTION
- makes mirage-channel testrun to work with mirage-flow 4.x+
- adapts #9 to the mirage-flow `shutdown` function
- remove deprecated Mirage_channel_lwt #35 
- adds the x-maintenance intent #36 
- fixes the README #26 